### PR TITLE
fix .travis.yml syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,4 @@ script:
   - scripts/build_pkg.sh && scripts/run_tests.sh
 after_script:
   - bash scripts/gather-coverage.sh
-- bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
   include:
     - env: GAPBRANCH=master ABI=64
     - env: GAPBRANCH=master ABI=32
-    - env: GAPBRANCH=stable-4.9
     - env: GAPBRANCH=stable-4.10
 
 branches:


### PR DESCRIPTION
Travis tests currently do not start because of a parsing error.